### PR TITLE
Fix category sync in popup and improve responsive layout

### DIFF
--- a/src/TimerPopup.tsx
+++ b/src/TimerPopup.tsx
@@ -7,6 +7,22 @@ const TimerPopup: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const lastMsgRef = useRef<{ revision: number; timestamp: number }>({ revision: 0, timestamp: 0 });
 
+  // Load selected category from localStorage on mount so the popup
+  // reflects the current selection immediately when opened
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('timerState');
+      if (saved) {
+        const parsed = JSON.parse(saved) as { selectedCategory?: string | null };
+        if (parsed && typeof parsed.selectedCategory !== 'undefined') {
+          setSelectedCategory(parsed.selectedCategory ?? null);
+        }
+      }
+    } catch {
+      // ignore JSON parse or storage errors
+    }
+  }, []);
+
   const handleMessage = (msg: TimerSyncMessage) => {
     const last = lastMsgRef.current;
     if (msg.revision < last.revision || (msg.revision === last.revision && msg.timestamp <= last.timestamp)) {

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,14 @@ body {
 .widget-mode {
   height: 100vh;
   padding: clamp(0.5rem, 2vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.widget-mode > * + * {
+  margin-top: clamp(0.5rem, 2vh, 1rem);
 }
 
 .widget-mode .timer-display {
@@ -57,6 +65,24 @@ body {
 .widget-mode .category-display {
   font-size: clamp(0.875rem, 3vw, 1.25rem);
   margin-bottom: clamp(0.5rem, 2vh, 1rem);
+}
+
+.widget-mode .date-display {
+  font-size: clamp(0.75rem, 2.5vw, 1rem);
+  margin-bottom: clamp(0.25rem, 1vh, 0.5rem);
+}
+
+.widget-mode label {
+  font-size: clamp(0.75rem, 2.5vw, 1rem);
+}
+
+.widget-mode .input {
+  font-size: clamp(0.75rem, 2.5vw, 1rem);
+  padding: clamp(0.25rem, 1vw, 0.5rem) clamp(0.5rem, 2vw, 1rem);
+}
+
+.widget-mode .timer-controls {
+  gap: clamp(0.375rem, 1vw, 0.75rem);
 }
 
 .widget-mode .timer-controls button {


### PR DESCRIPTION
## Summary
- load selected category from `timerState` when the popup mounts so the category
  is displayed immediately
- enhance `.widget-mode` styling so all elements scale together

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847bb4a21088324b63e9324b9a579ba