### PR TITLE
Redesign TimerPopup as compact widget

### DIFF
--- a/src/TimerPopup.tsx
+++ b/src/TimerPopup.tsx
@@ -90,52 +90,19 @@ const TimerPopup: React.FC = () => {
   }, []);
 
   return (
-    <div className="w-full h-full min-h-screen bg-gradient-to-br from-primary-50 via-neutral-50 to-accent-50 widget-mode">
-      <div className="w-full h-full flex flex-col items-center justify-center space-y-6 min-w-[300px] p-6">
-        {/* Header section with branding */}
-        <div className="text-center space-y-2">
-          <div className="inline-flex items-center justify-center w-12 h-12 bg-primary-600 rounded-full shadow-lg mb-2 transition-transform duration-300 hover:scale-105">
-            <div className="w-6 h-6 bg-white rounded-full opacity-90 transition-opacity duration-300 hover:opacity-100"></div>
-          </div>
-          <h1 className="text-lg font-semibold text-neutral-800 tracking-tight">Activity Timer</h1>
+    <div className="widget-mode flex items-center h-12 px-3 bg-white border-b gap-3 w-full min-w-[300px]">
+      {selectedCategory && (
+        <div className="text-sm font-medium text-gray-700 bg-gray-100 px-2 py-1 rounded whitespace-nowrap">
+          {selectedCategory}
         </div>
-
-        {/* Category display section */}
-        <div className="w-full max-w-sm">
-          {selectedCategory ? (
-            <div className="bg-white/80 backdrop-blur-sm rounded-xl border border-white/20 shadow-lg p-4 text-center">
-              <div className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-1">
-                Current Activity
-              </div>
-              <div className="text-xl font-semibold text-primary-700 category-display">
-                {selectedCategory}
-              </div>
-            </div>
-          ) : (
-            <div className="bg-neutral-100/80 backdrop-blur-sm rounded-xl border border-neutral-200/50 shadow-sm p-4 text-center">
-              <div className="text-sm text-neutral-600">
-                Please select a category in the main window
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Timer section */}
-        <div className="w-full max-w-sm bg-white/60 backdrop-blur-sm rounded-xl border border-white/30 shadow-xl p-4">
-          <Timer
-            onSave={handleSaveActivity}
-            selectedCategory={selectedCategory}
-            widgetMode={true}
-            readFromStorage={true}
-            writeToStorage={false}
-          />
-        </div>
-
-        {/* Footer with subtle branding */}
-        <div className="text-xs text-neutral-400 font-medium">
-          Activity Tracker
-        </div>
-      </div>
+      )}
+      <Timer
+        onSave={handleSaveActivity}
+        selectedCategory={selectedCategory}
+        widgetMode={true}
+        readFromStorage={true}
+        writeToStorage={false}
+      />
     </div>
   );
 };

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -300,86 +300,98 @@ export const Timer: React.FC<TimerProps> = ({
 
   return (
     <div
-      className={`card mb-6 ${widgetMode ? 'border-none shadow-none p-0 mb-0 bg-transparent' : ''}`}
+      className={`${
+        widgetMode
+          ? 'flex items-center gap-2 m-0 p-0 bg-transparent'
+          : 'card mb-6'
+      }`}
     >
-      <div className="text-neutral-600 text-center mb-2 date-display">
-        {currentDate}
-      </div>
+      {!widgetMode && (
+        <div className="text-neutral-600 text-center mb-2 date-display">
+          {currentDate}
+        </div>
+      )}
 
-      <div className="text-5xl font-semibold text-center font-mono my-4 text-primary-700 timer-display">
+      <div
+        className={`font-mono timer-display ${widgetMode ? 'text-xl' : 'text-5xl font-semibold text-center my-4 text-primary-700'}`}
+      >
         {formatTime(seconds)}
       </div>
 
-      <div className="grid grid-cols-1 gap-4 mb-4">
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 mb-1" htmlFor="startTime">
-            Start Time
-          </label>
-          <input
-            type="datetime-local"
-            id="startTime"
-            className="input"
-            value={startTimeLocal}
-            onChange={handleStartTimeChange}
-            disabled={isRunning}
-          />
+      {!widgetMode && (
+        <div className="grid grid-cols-1 gap-4 mb-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1" htmlFor="startTime">
+              Start Time
+            </label>
+            <input
+              type="datetime-local"
+              id="startTime"
+              className="input"
+              value={startTimeLocal}
+              onChange={handleStartTimeChange}
+              disabled={isRunning}
+            />
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="flex justify-center space-x-3 mt-4 timer-controls">
+      <div className={`flex ${widgetMode ? 'items-center gap-2' : 'justify-center space-x-3 mt-4'} timer-controls`}>
         <button
           onClick={handleStartStop}
           disabled={!selectedCategory}
-          className={`btn ${isRunning 
-            ? 'bg-primary-100 text-primary-800 hover:bg-primary-200' 
-            : 'btn-primary'} flex items-center justify-center gap-1`}
+          className={`btn ${
+            isRunning
+              ? 'bg-primary-100 text-primary-800 hover:bg-primary-200'
+              : 'btn-primary'
+          } flex items-center justify-center gap-1`}
         >
           {isRunning ? (
             <>
               <Pause size={18} />
-              <span>Pause</span>
+              {!widgetMode && <span>Pause</span>}
             </>
           ) : (
             <>
               <Play size={18} />
-              <span>Start</span>
+              {!widgetMode && <span>Start</span>}
             </>
           )}
         </button>
-        
+
         {isRunning && (
-          <button 
-            onClick={handleStop} 
+          <button
+            onClick={handleStop}
             className="btn bg-neutral-100 text-neutral-700 hover:bg-neutral-200 flex items-center justify-center gap-1"
           >
             <Square size={18} />
-            <span>Stop</span>
+            {!widgetMode && <span>Stop</span>}
           </button>
         )}
-        
+
         {seconds > 0 && (
-          <button 
-            onClick={handleSave} 
+          <button
+            onClick={handleSave}
             className="btn btn-primary flex items-center justify-center gap-1"
             disabled={!selectedCategory}
           >
             <Save size={18} />
-            <span>Save</span>
+            {!widgetMode && <span>Save</span>}
           </button>
         )}
-        
+
         {seconds > 0 && (
-          <button 
-            onClick={handleClear} 
+          <button
+            onClick={handleClear}
             className="btn bg-neutral-100 text-neutral-700 hover:bg-neutral-200 flex items-center justify-center gap-1"
           >
             <Trash2 size={18} />
-            <span className="sr-only">Clear</span>
+            {!widgetMode && <span className="sr-only">Clear</span>}
           </button>
         )}
       </div>
-      
-      {!selectedCategory && (
+
+      {!widgetMode && !selectedCategory && (
         <div className="mt-3 text-sm text-neutral-600 text-center">
           Please select a category to start tracking
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -175,3 +175,28 @@ body:has(.widget-mode) {
     font-size: clamp(1.75rem, 14vw, 3rem);
   }
 }
+
+/* Compact horizontal widget overrides */
+.widget-mode {
+  @apply flex-row items-center justify-start h-12 px-3 bg-white border-b gap-3;
+}
+
+.widget-mode::before {
+  display: none;
+}
+
+.widget-mode .timer-display {
+  font-size: 1.25rem !important;
+}
+
+.widget-mode .date-display {
+  display: none !important;
+}
+
+.widget-mode input[type="datetime-local"] {
+  display: none !important;
+}
+
+.widget-mode .timer-controls button span {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- simplify TimerPopup layout for horizontal widget
- adjust Timer component for widget mode
- override widget CSS styles for a compact horizontal toolbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847f6fe47f083249db1d4bc831cb5fe