### PR TITLE
Implement polished widget mode

### DIFF
--- a/src/TimerPopup.tsx
+++ b/src/TimerPopup.tsx
@@ -90,19 +90,21 @@ const TimerPopup: React.FC = () => {
   }, []);
 
   return (
-    <div className="widget-mode flex items-center h-12 px-3 bg-white border-b gap-3 w-full min-w-[300px]">
-      {selectedCategory && (
-        <div className="text-sm font-medium text-gray-700 bg-gray-100 px-2 py-1 rounded whitespace-nowrap">
-          {selectedCategory}
-        </div>
-      )}
-      <Timer
-        onSave={handleSaveActivity}
-        selectedCategory={selectedCategory}
-        widgetMode={true}
-        readFromStorage={true}
-        writeToStorage={false}
-      />
+    <div className="bg-white flex items-center px-3 shadow-sm" style={{ minHeight: '50px', maxHeight: '50px' }}>
+      <div className="flex items-center gap-3 w-full">
+        {selectedCategory && (
+          <div className="text-xs font-medium text-gray-600 bg-gray-50 px-2.5 py-1 rounded-sm">
+            {selectedCategory}
+          </div>
+        )}
+        <Timer
+          onSave={handleSaveActivity}
+          selectedCategory={selectedCategory}
+          widgetMode={true}
+          readFromStorage={true}
+          writeToStorage={false}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -298,6 +298,54 @@ export const Timer: React.FC<TimerProps> = ({
     }
   };
 
+  if (widgetMode) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="text-base font-mono font-medium min-w-[3.5rem]">
+          {formatTime(seconds)}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handleStartStop}
+            disabled={!selectedCategory}
+            className="w-7 h-7 rounded border border-gray-300 bg-white hover:bg-gray-50 flex items-center justify-center transition-colors"
+            style={{ padding: 0 }}
+          >
+            {isRunning ? <Pause size={14} /> : <Play size={14} />}
+          </button>
+          {isRunning && (
+            <button
+              onClick={handleStop}
+              className="w-7 h-7 rounded border border-gray-300 bg-white hover:bg-gray-50 flex items-center justify-center transition-colors"
+              style={{ padding: 0 }}
+            >
+              <Square size={14} />
+            </button>
+          )}
+          {seconds > 0 && (
+            <button
+              onClick={handleSave}
+              disabled={!selectedCategory}
+              className="w-7 h-7 rounded border border-gray-300 bg-white hover:bg-gray-50 flex items-center justify-center transition-colors"
+              style={{ padding: 0 }}
+            >
+              <Save size={14} />
+            </button>
+          )}
+          {seconds > 0 && (
+            <button
+              onClick={handleClear}
+              className="w-7 h-7 rounded border border-gray-300 bg-white hover:bg-gray-50 flex items-center justify-center transition-colors"
+              style={{ padding: 0 }}
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={`${


### PR DESCRIPTION
## Summary
- add new widget rendering path in `Timer`
- restyle `TimerPopup` for new compact widget

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847fb3bb670832483ed98138c807517