### PR TITLE
Fix popup window synchronization and features

### DIFF
--- a/src/TimerPopup.tsx
+++ b/src/TimerPopup.tsx
@@ -1,11 +1,65 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Timer } from './components/Timer';
-import { Activity } from './types';
-import { initTimerSync, addTimerSyncListener, TimerSyncMessage } from './utils/timerSync';
+import { Activity, StoredCategories, Note } from './types';
+import {
+  initTimerSync,
+  addTimerSyncListener,
+  broadcastTimerMessage,
+  TimerSyncMessage,
+  nextRevision,
+  getCurrentRevision
+} from './utils/timerSync';
+import { loadStoredCategories } from './utils';
+import { withActivitiesAtomic } from './utils/storage';
 
 const TimerPopup: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [customCategory, setCustomCategory] = useState('');
+  const [storedCategories] = useState<StoredCategories>(loadStoredCategories());
+  const [ongoingNotes, setOngoingNotes] = useState<Note[]>(() => {
+    try {
+      const saved = localStorage.getItem('ongoingNotes');
+      if (saved) return JSON.parse(saved);
+    } catch {
+      // ignore
+    }
+    return [];
+  });
+  const [currentNote, setCurrentNote] = useState('');
+  const [showNoteInput, setShowNoteInput] = useState(false);
+
+  const revisionRef = useRef(0);
   const lastMsgRef = useRef<{ revision: number; timestamp: number }>({ revision: 0, timestamp: 0 });
+
+  useEffect(() => {
+    revisionRef.current = getCurrentRevision();
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('ongoingNotes', JSON.stringify(ongoingNotes));
+    } catch {
+      // ignore
+    }
+  }, [ongoingNotes]);
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'ongoingNotes') {
+        if (e.newValue) {
+          try {
+            setOngoingNotes(JSON.parse(e.newValue));
+          } catch {
+            // ignore
+          }
+        } else {
+          setOngoingNotes([]);
+        }
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   // Load selected category from localStorage on mount so the popup
   // reflects the current selection immediately when opened
@@ -29,6 +83,7 @@ const TimerPopup: React.FC = () => {
       return;
     }
     lastMsgRef.current = { revision: msg.revision, timestamp: msg.timestamp };
+    revisionRef.current = msg.revision;
     if (msg.type === 'category-update') {
       setSelectedCategory(msg.payload.selectedCategory ?? null);
     }
@@ -39,6 +94,22 @@ const TimerPopup: React.FC = () => {
     const unsub = addTimerSyncListener(handleMessage);
     return () => unsub();
   }, []);
+
+  const sendMessage = (
+    type: TimerSyncMessage['type'],
+    payload: TimerSyncMessage['payload'] = {}
+  ) => {
+    const rev = nextRevision();
+    revisionRef.current = rev;
+    const msg: TimerSyncMessage = {
+      type,
+      revision: rev,
+      timestamp: Date.now(),
+      payload
+    };
+    lastMsgRef.current = { revision: rev, timestamp: msg.timestamp };
+    broadcastTimerMessage(msg);
+  };
 
   const handleSaveActivity = (
     duration: number,
@@ -68,8 +139,46 @@ const TimerPopup: React.FC = () => {
 
     const updated = [newActivity, ...activities];
     localStorage.setItem('activities', JSON.stringify(updated));
+    withActivitiesAtomic((acts) => [newActivity, ...acts]);
   };
 
+  const handleCategorySelect = (category: string) => {
+    setSelectedCategory(category);
+    try {
+      const savedTimer = localStorage.getItem('timerState');
+      const timerState = savedTimer ? JSON.parse(savedTimer) : {};
+      const now = new Date();
+      localStorage.setItem(
+        'timerState',
+        JSON.stringify({
+          ...timerState,
+          selectedCategory: category,
+          isRunning: timerState.isRunning ?? false,
+          startTime: timerState.startTime ?? now.toISOString(),
+          lastCheckpoint: timerState.lastCheckpoint ?? now.toISOString()
+        })
+      );
+    } catch {
+      // ignore
+    }
+    sendMessage('category-update', { selectedCategory: category });
+  };
+
+  const handleAddNote = () => {
+    if (!currentNote.trim()) return;
+    const newNote: Note = {
+      id: crypto.randomUUID(),
+      content: currentNote,
+      timestamp: new Date().toISOString()
+    };
+    setOngoingNotes(prev => [...prev, newNote]);
+    setShowNoteInput(false);
+    setCurrentNote('');
+  };
+  const handleCancelNote = () => {
+    setShowNoteInput(false);
+    setCurrentNote("");
+  };
   // Remember window size/position
   useEffect(() => {
     const handleUnload = () => {
@@ -90,20 +199,85 @@ const TimerPopup: React.FC = () => {
   }, []);
 
   return (
-    <div className="bg-white flex items-center px-3 shadow-sm" style={{ minHeight: '50px', maxHeight: '50px' }}>
-      <div className="flex items-center gap-3 w-full">
-        {selectedCategory && (
-          <div className="text-xs font-medium text-gray-600 bg-gray-50 px-2.5 py-1 rounded-sm">
-            {selectedCategory}
-          </div>
-        )}
-        <Timer
-          onSave={handleSaveActivity}
-          selectedCategory={selectedCategory}
-          widgetMode={true}
-          readFromStorage={true}
-          writeToStorage={false}
+    <div className="bg-white p-2 shadow-sm flex items-center gap-2 w-full">
+      <div className="flex items-center gap-1">
+        <span className="text-xs font-medium">
+          {selectedCategory === 'Other' ? customCategory || 'Other' : selectedCategory || 'No category'}
+        </span>
+        <select
+          value={selectedCategory ?? ''}
+          onChange={(e) => handleCategorySelect(e.target.value)}
+          className="text-xs border rounded px-1 py-0.5"
+        >
+          <option value="">Select</option>
+          {storedCategories.categories.work.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+          {storedCategories.categories.personal.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </div>
+      {selectedCategory === 'Other' && (
+        <input
+          type="text"
+          value={customCategory}
+          onChange={(e) => setCustomCategory(e.target.value)}
+          placeholder="Custom"
+          className="border rounded px-1 py-0.5 text-xs w-24"
         />
+      )}
+      <Timer
+        onSave={handleSaveActivity}
+        selectedCategory={selectedCategory === 'Other' ? customCategory || 'Other' : selectedCategory}
+        widgetMode={true}
+        readFromStorage={true}
+        writeToStorage={true}
+      />
+      <div className="flex items-center gap-1">
+        {showNoteInput ? (
+          <>
+            <input
+              type="text"
+              value={currentNote}
+              onChange={(e) => setCurrentNote(e.target.value)}
+              placeholder="Note"
+              className="border rounded px-1 py-0.5 text-xs w-28"
+            />
+            <button
+              onClick={handleAddNote}
+              disabled={!currentNote.trim()}
+              className="px-1 py-0.5 text-xs rounded bg-primary-600 text-white disabled:opacity-50"
+            >
+              Save
+            </button>
+            <button
+              onClick={handleCancelNote}
+              className="px-1 py-0.5 text-xs rounded bg-neutral-200"
+            >
+              ×
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => setShowNoteInput(true)}
+              className="px-2 py-0.5 text-xs border rounded"
+            >
+              Add Note
+            </button>
+            {ongoingNotes.length > 0 && (
+              <span className="text-xs text-neutral-600 truncate max-w-[100px]">
+                {ongoingNotes[ongoingNotes.length - 1].content}
+                {ongoingNotes.length > 1 && ` (+${ongoingNotes.length - 1})`}
+              </span>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,30 @@
+import { Activity } from '../types';
+
+export function withActivitiesAtomic(fn: (activities: Activity[]) => Activity[]): void {
+  const KEY = 'activities';
+  const REV_KEY = 'activitiesRevision';
+  for (let i = 0; i < 5; i++) {
+    let data: Activity[] = [];
+    let rev = 0;
+    try {
+      const saved = localStorage.getItem(KEY);
+      if (saved) data = JSON.parse(saved) || [];
+    } catch {
+      // ignore
+    }
+    try {
+      rev = parseInt(localStorage.getItem(REV_KEY) || '0', 10);
+    } catch {
+      // ignore
+    }
+    const updated = fn([...data]);
+    try {
+      localStorage.setItem(KEY, JSON.stringify(updated));
+      localStorage.setItem(REV_KEY, String(rev + 1));
+    } catch {
+      // ignore
+    }
+    const verify = parseInt(localStorage.getItem(REV_KEY) || '0', 10);
+    if (verify === rev + 1) return;
+  }
+}


### PR DESCRIPTION
## Summary
- maintain shared revision counter for timer messages
- add atomic storage helper and use it for activity updates
- persist popup bounds when opening and restore saved size
- implement categories and notes in popup window
- enable timer persistence across windows
- compact popup layout with dropdown category and collapsible notes

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6848ca8308fc8324b0918ea49e39c58c