### PR TITLE
Fix timer synchronization issues

### DIFF
--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -148,20 +148,7 @@ export const Timer: React.FC<TimerProps> = ({
     }
   }, [readFromStorage]);
 
-  // Save timer state to localStorage whenever it changes
-  useEffect(() => {
-    if (!writeToStorage) return;
-    
-    const timerState: TimerState = {
-      isRunning,
-      startTime,
-      lastCheckpoint: new Date().toISOString(),
-      selectedCategory
-    };
-    localStorage.setItem('timerState', JSON.stringify(timerState));
-  }, [isRunning, startTime, selectedCategory, writeToStorage]);
-
-
+  // Interval updates for running timer
   useEffect(() => {
     let interval: number | undefined;
     
@@ -244,7 +231,9 @@ export const Timer: React.FC<TimerProps> = ({
     const nowISO = toISO(new Date());
     setStartTime(nowISO);
     setStartTimeLocal(formatForDateTimeInput(nowISO));
-    localStorage.removeItem('timerState');
+    if (writeToStorage) {
+      localStorage.removeItem('timerState');
+    }
     sendMessage('timer-clear', { isRunning: false, startTime: nowISO });
   };
 
@@ -267,7 +256,9 @@ export const Timer: React.FC<TimerProps> = ({
     const nowISO = toISO(new Date());
     setStartTime(nowISO);
     setStartTimeLocal(formatForDateTimeInput(nowISO));
-    localStorage.removeItem('timerState');
+    if (writeToStorage) {
+      localStorage.removeItem('timerState');
+    }
     sendMessage('timer-save', { isRunning: false, startTime: nowISO });
   };
 


### PR DESCRIPTION
## Summary
- centralize timer state updates via broadcast channel
- drop direct timer localStorage writes
- add sync listeners for App and popup
- keep popup category list fresh from storage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849eed74de4832483072bf764e861f2